### PR TITLE
「ページへ戻る」ボタンについてのヘルパーを作成しました

### DIFF
--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -28,30 +28,16 @@ class BackToPageHelper extends AppHelper {
  * @param string $size  '' デフォルトサイズ : xs / sm / xs
  * @return string
  */
-	public function backToPageButton($frameId, $title, $icon = '', $size = '') {
+	public function backToPageButton($title, $icon = '', $size = '') {
 		if (isset($this->request->params['requested'])) {
 			return '';
 		}
-
-		$Frame = Classregistry::init('Frames.Frame');
-		$Page = Classregistry::init('Pages.Page');
-
-		$frames = $Frame->find('first',
-			array('conditions' => array('Frame.id' => $frameId)));
-		if (!$frames || !isset($frames['Box']['page_id'])) {
-			return '';
-		}
-		$pages = $Page->find('first',
-			array('conditions' => array('Page.id' => $frames['Box']['page_id'])));
-		if (!$pages || !isset($pages['Page']['permalink'])) {
-			return '';
-		}
-
-		$topUrl = $pages['Page']['permalink'];
+		$topUrl = $this->_View->viewVars['cancelUrl'];
 		$iconElement = '';
 		if ($icon != '') {
 			$iconElement = '<span class="glyphicon glyphicon-' . $icon . '"></span>';
 		}
+		var_dump($iconElement);
 		$sizeAttr = '';
 		if ($size != '') {
 			$sizeAttr = 'btn-' . $size;

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -38,8 +38,14 @@ class BackToPageHelper extends AppHelper {
 
 		$frames = $Frame->find('first',
 			array('conditions' => array('Frame.id' => $frameId)));
+		if (!$frames || !isset($frames['Box']['page_id'])) {
+			return '';
+		}
 		$pages = $Page->find('first',
 			array('conditions' => array('Page.id' => $frames['Box']['page_id'])));
+		if (!$pages || !isset($pages['Page']['permalink'])) {
+			return '';
+		}
 
 		$topUrl = $pages['Page']['permalink'];
 		$iconElement = '';

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -20,11 +20,11 @@ App::uses('AppHelper', 'View/Helper');
 class BackToPageHelper extends AppHelper {
 
 /**
- * getPageTopButton 最初のページに戻る
+ * getPageTopButton Go back to the page where the plugin has been first displayed
  *
- * @param string $title ボタンに表示するタイトル文字列
- * @param string $icon ボタンに表示するアイコン(bootstrap componentsのgliphsの最後のキーワードのみ指定する)
- * @param string $size  '' デフォルトサイズ : xs / sm / xs
+ * @param string $title Title string to be displayed on the button
+ * @param string $icon Icon to be displayed on the button (only to specify the last keyword of gliphs of bootstrap components)
+ * @param string $size  '' is the default size : lg / sm / xs
  * @return string
  */
 	public function backToPageButton($title, $icon = '', $size = '') {

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * BackToPageHelper Helper
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author AllCreator co. <info@allcreator>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+App::uses('AppHelper', 'View/Helper');
+
+/**
+ * BackToPageHelper Helper
+ *
+ * @author AllCreator co. <info@allcreator>
+ * @package NetCommons\NetCommons\View\Helper
+ */
+class BackToPageHelper extends AppHelper {
+
+/**
+ * getPageTopButton 最初のページに戻る
+ *
+ * @param int $frameId フレームID
+ * @param string $title ボタンに表示するタイトル文字列
+ * @param string $icon ボタンに表示するアイコン(bootstrap componentsのgliphsの最後のキーワードのみ指定する)
+ * @param string $size  '' デフォルトサイズ : xs / sm / xs
+ * @return string
+ */
+	public function backToPageButton($frameId, $title, $icon = '', $size = '') {
+		if (isset($this->request->params['requested'])) {
+			return '';
+		}
+
+		$Frame = Classregistry::init('Frames.Frame');
+		$Page = Classregistry::init('Pages.Page');
+
+		$frames = $Frame->find('first',
+			array('conditions' => array('Frame.id' => $frameId)));
+		$pages = $Page->find('first',
+			array('conditions' => array('Page.id' => $frames['Box']['page_id'])));
+
+		$topUrl = $pages['Page']['permalink'];
+		$iconElement = '';
+		if ($icon != '') {
+			$iconElement = '<span class="glyphicon glyphicon-' . $icon . '"></span>';
+		}
+		$sizeAttr = '';
+		if ($size != '') {
+			$sizeAttr = 'btn-' . $size;
+		}
+		$html = '<a class="btn btn-default' . $sizeAttr . '" href="/' . $topUrl . '">' . $iconElement . $title . '</a>';
+
+		return $html;
+	}
+
+}

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -36,7 +36,6 @@ class BackToPageHelper extends AppHelper {
 		if ($icon != '') {
 			$iconElement = '<span class="glyphicon glyphicon-' . $icon . '"></span>';
 		}
-		var_dump($iconElement);
 		$sizeAttr = '';
 		if ($size != '') {
 			$sizeAttr = 'btn-' . $size;
@@ -45,5 +44,4 @@ class BackToPageHelper extends AppHelper {
 
 		return $html;
 	}
-
 }

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -20,7 +20,7 @@ App::uses('AppHelper', 'View/Helper');
 class BackToPageHelper extends AppHelper {
 
 /**
- * getPageTopButton Go back to the page where the plugin has been first displayed
+ * backToPageButton Go back to the page where the plugin has been first displayed
  *
  * @param string $title Title string to be displayed on the button
  * @param string $icon Icon to be displayed on the button (only to specify the last keyword of gliphs of bootstrap components)
@@ -40,7 +40,7 @@ class BackToPageHelper extends AppHelper {
 		if ($size != '') {
 			$sizeAttr = 'btn-' . $size;
 		}
-		$html = '<a class="btn btn-default' . $sizeAttr . '" href="/' . $topUrl . '">' . $iconElement . $title . '</a>';
+		$html = '<a class="btn btn-default ' . $sizeAttr . '" href="/' . $topUrl . '">' . $iconElement . $title . '</a>';
 
 		return $html;
 	}

--- a/View/Helper/BackToPageHelper.php
+++ b/View/Helper/BackToPageHelper.php
@@ -22,7 +22,6 @@ class BackToPageHelper extends AppHelper {
 /**
  * getPageTopButton 最初のページに戻る
  *
- * @param int $frameId フレームID
  * @param string $title ボタンに表示するタイトル文字列
  * @param string $icon ボタンに表示するアイコン(bootstrap componentsのgliphsの最後のキーワードのみ指定する)
  * @param string $size  '' デフォルトサイズ : xs / sm / xs


### PR DESCRIPTION
frameIdを指示されると自動的に、そのフレームが配置されているパーマリンクを取得して、ページ表示に戻るためのボタンを提供します。

ボタンテキスト、アイコン、サイズは指定できるようにしています。

ヘルパーからModelを参照しているのがいただけない作りです。
permalinkがviewVarsなどの属性値に格納されているなどの情報ありましたらご教示ください。そちらを参照するように作りを変更します。