### PR TITLE
親constructorを呼ぶように修正

### DIFF
--- a/TestSuite/YACakeTestCase.php
+++ b/TestSuite/YACakeTestCase.php
@@ -64,7 +64,8 @@ class YACakeTestCase extends CakeTestCase {
  *
  * @return void
  */
-	public function __construct() {
+	public function __construct($name = NULL, array $data = array(), $dataName = '') {
+		parent::__construct($name, $data, $dataName);
 		if ($this->_isFixtureMerged) {
 			$this->fixtures = array_merge($this->fixtures, $this->_fixtures);
 		}


### PR DESCRIPTION
親コンストラクタ呼んで無くてPHPUnitのdataProviderが使えなかったので、親コンストラクタ呼ぶように修正。
コンストラクタ引数も元親にあわせた