### PR TITLE
CakeTestCase::getMockForModel()を使用すると、slaveを見に行ってしまう不具合を修正

### DIFF
--- a/Model/NetCommonsAppModel.php
+++ b/Model/NetCommonsAppModel.php
@@ -79,6 +79,9 @@ class NetCommonsAppModel extends Model {
 			parent::__construct($id, $table, $ds);
 			return;
 		}
+		if (Hash::get((array)$id, 'testing') && $this->useDbConfig !== 'test') {
+			$this->useDbConfig = 'test';
+		}
 
 		// Use a static variable, to only use one connection per page-call (otherwise we would get a new handle every time a Model is created)
 		static $_useDbConfig;


### PR DESCRIPTION
FaqsプラグインのUnitTestで発見