### PR TITLE
fix remove cr-lf from expects before assert RegExp

### DIFF
--- a/TestSuite/NetCommonsControllerTestCase.php
+++ b/TestSuite/NetCommonsControllerTestCase.php
@@ -434,6 +434,7 @@ class NetCommonsControllerTestCase extends ControllerTestCase {
  */
 	public function assertInput($tagType, $name, $value, $result, $message = null) {
 		$result = str_replace("\n", '', $result);
+
 		if ($tagType === 'input') {
 			if ($value) {
 				$this->assertRegExp(

--- a/TestSuite/NetCommonsControllerTestCase.php
+++ b/TestSuite/NetCommonsControllerTestCase.php
@@ -433,6 +433,7 @@ class NetCommonsControllerTestCase extends ControllerTestCase {
  * @return void
  */
 	public function assertInput($tagType, $name, $value, $result, $message = null) {
+		$result = str_replace("\n", '', $result);
 		if ($tagType === 'input') {
 			if ($value) {
 				$this->assertRegExp(
@@ -450,6 +451,10 @@ class NetCommonsControllerTestCase extends ControllerTestCase {
 		} elseif ($tagType === 'button') {
 			$this->assertRegExp(
 				'/<button.*?name="' . preg_quote($name, '/') . '".*?>/', $result, $message
+			);
+		} elseif ($tagType === 'select') {
+			$this->assertRegExp(
+				'/<select.*?name="' . preg_quote($name, '/') . '".*?>/', $result, $message
 			);
 		} elseif ($tagType === 'form') {
 			$this->assertRegExp(


### PR DESCRIPTION
assertInputのRegExpチェック時、出力結果のタグ記述に改行コードが含まれていることが考慮されていませんでした。
HTMLのタグ内部で改行コードが含まれている場合、内容が一致していても不正とみられていたため、判定前に改行コードを取り除くようにしました。
また、Input判定にselectタイプも増やしています。