### PR TITLE
MathJax js を読み込む対応

### DIFF
--- a/View/Elements/common_js.ctp
+++ b/View/Elements/common_js.ctp
@@ -19,3 +19,5 @@ echo $this->Html->script(
 	),
 	array('plugin' => false)
 );
+
+echo $this->element('Wysiwyg.mathjax_js');


### PR DESCRIPTION
View/Elements/common_js.ctp　にて
Wysiwygプラグインで定義した elementを読み込む対応。

MathJaxの jsファイルは Wysiwygプラグインの bowerで定義。