### PR TITLE
TestSuiteの_defaultFixturesにblock_settingを追加

### DIFF
--- a/TestSuite/NetCommonsCakeTestCase.php
+++ b/TestSuite/NetCommonsCakeTestCase.php
@@ -60,6 +60,7 @@ class NetCommonsCakeTestCase extends CakeTestCase {
 	protected $_defaultFixtures = array(
 		'plugin.blocks.block',
 		'plugin.blocks.block_role_permission',
+		'plugin.blocks.block_setting',
 		'plugin.boxes.box',
 		'plugin.boxes.boxes_page',
 		'plugin.containers.container',

--- a/TestSuite/NetCommonsControllerBaseTestCase.php
+++ b/TestSuite/NetCommonsControllerBaseTestCase.php
@@ -66,6 +66,7 @@ class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 	protected $_fixtures = array(
 		'plugin.blocks.block',
 		'plugin.blocks.block_role_permission',
+		'plugin.blocks.block_setting',
 		'plugin.boxes.box',
 		'plugin.boxes.boxes_page',
 		'plugin.categories.category',


### PR DESCRIPTION
メールキュー保存時にuse_workflowなどBlockSettingを参照するようになったため
