### PR TITLE
空値でもTimeZoneが必ず変換されてしまうため、空の時は変換しないように修正。

### DIFF
--- a/Utility/NetCommonsTime.php
+++ b/Utility/NetCommonsTime.php
@@ -82,8 +82,10 @@ class NetCommonsTime {
 		$userDatetimeData = $data;
 		$convertKeyNameList = Hash::filter($convertKeyNameList);
 		foreach ($convertKeyNameList as $keyName) {
-			$_userDatetime = $this->toUserDatetime(Hash::get($data, $keyName));
-			$userDatetimeData = Hash::insert($userDatetimeData, $keyName, $_userDatetime);
+			if (Hash::get($data, $keyName)) {
+				$_userDatetime = $this->toUserDatetime(Hash::get($data, $keyName));
+				$userDatetimeData = Hash::insert($userDatetimeData, $keyName, $_userDatetime);
+			}
 		}
 		//
 		//foreach ($userDatetimeData as $key => $value) {
@@ -127,8 +129,10 @@ class NetCommonsTime {
 		$serverDatetimeData = $data;
 		$convertKeyNameList = Hash::filter($convertKeyNameList);
 		foreach ($convertKeyNameList as $keyName) {
-			$_serverDatetime = $this->toServerDatetime(Hash::get($data, $keyName), $userTimezone);
-			$serverDatetimeData = Hash::insert($serverDatetimeData, $keyName, $_serverDatetime);
+			if (Hash::get($data, $keyName)) {
+				$_serverDatetime = $this->toServerDatetime(Hash::get($data, $keyName), $userTimezone);
+				$serverDatetimeData = Hash::insert($serverDatetimeData, $keyName, $_serverDatetime);
+			}
 		}
 
 		//foreach ($serverDatetimeData as $key => $value) {

--- a/View/Helper/DatetimePickerHelper.php
+++ b/View/Helper/DatetimePickerHelper.php
@@ -161,9 +161,11 @@ class DatetimePickerHelper extends AppHelper {
 			} elseif (isset($options['default'])) {
 				$value = $options['default'];
 			}
-			$netCommonsTime = new NetCommonsTime();
 
-			$value = $netCommonsTime->toUserDatetime($value);
+			if ($value !== false) {
+				$netCommonsTime = new NetCommonsTime();
+				$value = $netCommonsTime->toUserDatetime($value);
+			}
 			$options['value'] = $value;
 			$options['ng-value'] = $options['ng-model'];
 


### PR DESCRIPTION
また、Datatimepickerも空値の場合、現在時刻が無条件でセットされてしまうため、default=falseにしたら、セットしないように修正。