### PR TITLE
CakePHPv2.5.7以前は強制的にtruncateされていたため、同テーブルで別名のFixtureが定義されていても動作していたが、…

### DIFF
--- a/TestSuite/NetCommonsCakeTestCase.php
+++ b/TestSuite/NetCommonsCakeTestCase.php
@@ -53,6 +53,15 @@ class NetCommonsCakeTestCase extends CakeTestCase {
 	protected $_isFixtureMerged = true;
 
 /**
+ * CakePHPv2.5.7以前は強制的にtruncateされていたため、同テーブルで別名のFixtureが定義されていても動作していたが、
+ * dropTables=falseにしないとtruncateしなくなった。
+ *
+ * @var bool
+ * @see https://github.com/cakephp/cakephp/blob/2.8.7/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php#L232-L234
+ */
+	public $dropTables = false;
+
+/**
  * Fixtures
  *
  * @var array

--- a/TestSuite/NetCommonsControllerBaseTestCase.php
+++ b/TestSuite/NetCommonsControllerBaseTestCase.php
@@ -31,6 +31,15 @@ App::uses('SiteSettingUtil', 'SiteManager.Utility');
 class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 
 /**
+ * CakePHPv2.5.7以前は強制的にtruncateされていたため、同テーブルで別名のFixtureが定義されていても動作していたが、
+ * dropTables=falseにしないとtruncateしなくなった。
+ *
+ * @var bool
+ * @see https://github.com/cakephp/cakephp/blob/2.8.7/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php#L232-L234
+ */
+	public $dropTables = false;
+
+/**
  * Plugin name
  *
  * @var string


### PR DESCRIPTION
…dropTables=falseにしないとtruncateしなくなった。

https://github.com/cakephp/cakephp/blob/2.8.7/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php#L232-L234