### PR TITLE
cakeのAuthComponent::user()でSessionを使わないように$sessionKeyをOffにする

### DIFF
--- a/TestSuite/NetCommonsControllerBaseTestCase.php
+++ b/TestSuite/NetCommonsControllerBaseTestCase.php
@@ -146,6 +146,8 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 		Configure::write('Config.language', 'ja');
 		(new CurrentSystem())->setLanguage();
 
+		AuthComponent::$sessionKey = false;
+
 		if ($this->_controller) {
 			$this->generateNc(Inflector::camelize($this->_controller));
 		}


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/998