### PR TITLE
Exceptionエラーテストを実行すると、tearDownが実行されず、ログイン情報等が初期化されないため、setUpで初期化するように修正

### DIFF
--- a/Test/Case/Model/Behavior/Trackable/TrackableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/Trackable/TrackableBehaviorTest.php
@@ -9,6 +9,9 @@
  */
 
 App::uses('TrackableBehaviorTestBase', 'NetCommons.Test/Case/Model/Behavior/Trackable');
+App::uses('AuthComponent', 'Controller/Component');
+App::uses('Role', 'Roles.Model');
+App::uses('TestAuthGeneral', 'AuthGeneral.TestSuite');
 
 /**
  * TrackableBehaviorTest
@@ -22,8 +25,13 @@ class TrackableBehaviorTest extends TrackableBehaviorTestBase {
  * @return void
  */
 	protected function _testFieldPopulation($authCallback) {
+		$reflectionClass = new ReflectionClass('AuthComponent');
+		$property = $reflectionClass->getProperty('_user');
+		$property->setAccessible(true);
+
 		$this->{$authCallback}();
 
+		$property->setValue($this, TestAuthGeneral::$roles[Role::ROOM_ROLE_KEY_ROOM_ADMINISTRATOR]);
 		$this->model->create(array('id' => 1, 'title' => 'foobar'));
 		$result = $this->model->save();
 		$data = $result['TestModel'];
@@ -35,6 +43,7 @@ class TrackableBehaviorTest extends TrackableBehaviorTestBase {
 		unset($data['modified_user']);
 		unset($data['modified']);
 
+		$property->setValue($this, TestAuthGeneral::$roles[Role::ROOM_ROLE_KEY_CHIEF_EDITOR]);
 		$this->{$authCallback}('id', 2);
 
 		$data['title'] = 'spameggs';
@@ -47,6 +56,8 @@ class TrackableBehaviorTest extends TrackableBehaviorTestBase {
 		$this->assertTrue(array_key_exists('TrackableUpdater', $result));
 		$this->assertEquals(1, $data['created_user']);
 		$this->assertEquals(2, $data['modified_user']);
+
+		$property->setValue($this, []);
 	}
 
 /**

--- a/Test/Case/Model/Behavior/Trackable/TrackableBehaviorTestBase.php
+++ b/Test/Case/Model/Behavior/Trackable/TrackableBehaviorTestBase.php
@@ -66,7 +66,7 @@ class TrackableUserModel extends AppModel {
 /**
  * Base class of TrackableBehavior test case
  */
-class TrackableBehaviorTestBase extends NetCommonsCakeTestCase {
+abstract class TrackableBehaviorTestBase extends NetCommonsCakeTestCase {
 
 /**
  * Fixtures

--- a/TestSuite/NetCommonsCakeTestCase.php
+++ b/TestSuite/NetCommonsCakeTestCase.php
@@ -126,6 +126,8 @@ abstract class NetCommonsCakeTestCase extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		$this->_clear();
+
 		parent::setUp();
 
 		Configure::write('NetCommons.installed', true);
@@ -142,7 +144,7 @@ abstract class NetCommonsCakeTestCase extends CakeTestCase {
  *
  * @return void
  */
-	public function tearDown() {
+	protected function _clear() {
 		if ($this->_modelName) {
 			$model = $this->_modelName;
 			unset($this->$model);
@@ -156,7 +158,14 @@ abstract class NetCommonsCakeTestCase extends CakeTestCase {
 		Current::$permission = array();
 
 		OriginalKeyBehavior::$isUnitRandomKey = false;
+	}
 
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
 		parent::tearDown();
 	}
 

--- a/TestSuite/NetCommonsControllerBaseTestCase.php
+++ b/TestSuite/NetCommonsControllerBaseTestCase.php
@@ -21,6 +21,7 @@ App::uses('NetCommonsCakeTestCase', 'NetCommons.TestSuite');
 App::uses('Role', 'Roles.Model');
 App::uses('SiteSettingUtil', 'SiteManager.Utility');
 App::uses('OriginalKeyBehavior', 'NetCommons.Model/Behavior');
+App::uses('AuthComponent', 'Controller/Component');
 
 /**
  * NetCommonsControllerTestCase
@@ -141,11 +142,16 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 	public function setUp() {
 		NetCommonsCakeTestCase::loadTestPlugin($this, 'NetCommons', 'TestPlugin');
 
+		$this->_clear();
+
 		parent::setUp();
 
 		Configure::write('NetCommons.installed', true);
 		Configure::write('Config.language', 'ja');
-		(new CurrentSystem())->setLanguage();
+		Current::$current['Language'] = [
+			'id' => '2',
+			'code' => 'ja',
+		];
 
 		AuthComponent::$sessionKey = false;
 
@@ -155,11 +161,11 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 	}
 
 /**
- * tearDown method
+ * 初期化
  *
  * @return void
  */
-	public function tearDown() {
+	protected function _clear() {
 		Configure::write('NetCommons.installed', false);
 		Configure::write('Config.language', null);
 		CakeSession::write('Auth.User', null);
@@ -171,6 +177,14 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 		OriginalKeyBehavior::$isUnitRandomKey = false;
 
 		SiteSettingUtil::reset();
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
 		parent::tearDown();
 	}
 
@@ -213,6 +227,9 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 		}
 
 		$this->generate($plugin . '.' . $controller, Hash::merge($default, $mocks));
+
+		//throwが実行されるとログイン情報が残っているため、初期化する
+		TestAuthGeneral::logout($this);
 	}
 
 /**

--- a/TestSuite/NetCommonsControllerBaseTestCase.php
+++ b/TestSuite/NetCommonsControllerBaseTestCase.php
@@ -263,14 +263,15 @@ abstract class NetCommonsControllerBaseTestCase extends ControllerTestCase {
 	}
 
 /**
- * 日時の評価
+ * Assert Date time
  *
- * @param string $result 期待値
+ * @param string $result Result data
  * @param string $message メッセージ
  * @return void
  */
 	public function assertDatetime($result, $message = null) {
-		(new NetCommonsCakeTestCase())->assertDatetime($result, $message);
+		$pattern = '/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/';
+		$this->assertRegExp($pattern, $result, $message);
 	}
 
 /**


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/998