### PR TITLE
アクセスチェックのためのSpace情報取得をRoomモデルを使ってのgetSpacesからSpaceモデルを使ってのgetSpacesに変更

### DIFF
--- a/Controller/Component/PermissionComponent.php
+++ b/Controller/Component/PermissionComponent.php
@@ -233,8 +233,9 @@ class PermissionComponent extends Component {
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 	public function checkSpaceAccess(Controller $controller) {
-		$Room = ClassRegistry::init('Rooms.Room');
-		$spaces = $Room->getSpaces();
+		$Space = ClassRegistry::init('Rooms.Space');
+		$spaces = $Space->getSpaces();
+		$spaces = Hash::combine($spaces, '{n}.Space.id', 'Space');
 		$curRoom = Current::read('Room');
 		if ($spaces && $curRoom) {
 			if (empty($this->SpaceComponent)) {

--- a/Controller/Component/PermissionComponent.php
+++ b/Controller/Component/PermissionComponent.php
@@ -234,8 +234,11 @@ class PermissionComponent extends Component {
  */
 	public function checkSpaceAccess(Controller $controller) {
 		$Space = ClassRegistry::init('Rooms.Space');
-		$spaces = $Space->getSpaces();
-		$spaces = Hash::combine($spaces, '{n}.Space.id', 'Space');
+		$getSpaces = $Space->getSpaces();
+		$spaces = array();
+		foreach ($getSpaces as $space) {
+			$spaces[$space['Space']['id']] = $space;
+		}
 		$curRoom = Current::read('Room');
 		if ($spaces && $curRoom) {
 			if (empty($this->SpaceComponent)) {


### PR DESCRIPTION
特有のSpace情報を追加したときにもaccessCheckが使えるようにするため