### PR TITLE
Wyswigyのメニューで、JS、CSS、画像がキャッシュとられないものがあったため、キャッシュをとるURLを指定するように修正

### DIFF
--- a/View/Helper/NetCommonsHtmlHelper.php
+++ b/View/Helper/NetCommonsHtmlHelper.php
@@ -249,6 +249,11 @@ class NetCommonsHtmlHelper extends AppHelper {
  */
 	public function url($url = null, $options = array()) {
 		//URLの設定
+		if (is_string($url)) {
+			$paths = $this->__convertWebrootPath($url);
+			$url = $paths[0];
+		}
+
 		$url = $this->__getUrl($url, $options);
 		$output = $this->Html->url($url, $options);
 		return $output;


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1364
https://github.com/NetCommons3/NetCommons3/issues/1360