### PR TITLE
fix: 追加したパブリックルームをトップページとして一番上に移動しても表示されるように修正

### DIFF
--- a/Utility/CurrentPage.php
+++ b/Utility/CurrentPage.php
@@ -268,7 +268,7 @@ class CurrentPage {
 		$result = $this->__getPage(array(
 			'recursive' => -1,
 			'conditions' => array(
-				'Page.room_id' => Space::getRoomIdRoot(Space::PUBLIC_SPACE_ID),
+				'Page.root_id' => Space::getRoomIdRoot(Space::PUBLIC_SPACE_ID),
 				'Page.parent_id NOT' => null,
 			),
 			'order' => array('Page.sort_key' => 'asc')


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1394

バグ修正のプルリクエストです。
マージできるか、もくもく会で相談してから決めます。
