### PR TITLE
array_key_existsに第3引数は無い

### DIFF
--- a/Controller/Component/AppPaginatorComponent.php
+++ b/Controller/Component/AppPaginatorComponent.php
@@ -37,7 +37,7 @@ class AppPaginatorComponent extends PaginatorComponent {
 		if (in_array('Paginator', $this->Controller->helpers, true)) {
 			$index = array_search('Paginator', $this->Controller->helpers, true);
 			unset($this->Controller->helpers[$index]);
-		} elseif (array_key_exists('Paginator', $this->Controller->helpers, true)) {
+		} elseif (array_key_exists('Paginator', $this->Controller->helpers)) {
 			unset($this->Controller->helpers['Paginator']);
 		}
 		$this->Controller->helpers['Paginator'] = array('className' => 'NetCommons.AppPaginator');


### PR DESCRIPTION
```
array_key_exists() expects exactly 2 parameters, 3 given [APP/Plugin/NetCommons/Controller/Component/AppPaginatorComponent.php, line 40]
が発生したので修正
```

参考 http://php.net/manual/ja/function.array-key-exists.php
```