### PR TITLE
大量データのテストは、Travisでメモリエラーになるため、PHP7のみ行うように修正

### DIFF
--- a/Test/Case/Utility/Hash/HashSpeedupTestNoExec.php
+++ b/Test/Case/Utility/Hash/HashSpeedupTestNoExec.php
@@ -50,6 +50,21 @@ class HashSpeedupTestNoExec extends CakeTestCase {
 	private $__data = [];
 
 /**
+ * Runs the test case and collects the results in a TestResult object.
+ * If no TestResult object is passed a new one will be created.
+ * This method is run for each test method in this class
+ *
+ * @param PHPUnit_Framework_TestResult $result The test result object
+ * @return PHPUnit_Framework_TestResult
+ * @throws InvalidArgumentException
+ */
+	public function run(PHPUnit_Framework_TestResult $result = null) {
+		if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+			return parent::run($result);
+		}
+	}
+
+/**
  * setUp method
  *
  * @return void
@@ -58,7 +73,7 @@ class HashSpeedupTestNoExec extends CakeTestCase {
 		parent::setUp();
 
 		//大量データ作成
-		if (! $this->__data) {
+		if (! $this->__data && self::MEASUREMENT_NUMBER > 0) {
 			for ($i = 1; $i <= 10; $i++) {
 				$this->__data['AAAAAA'][$i] = [
 					'key' => 'aaaaa_key_' . $i,

--- a/Test/Case/Utility/Hash/HashTest.php
+++ b/Test/Case/Utility/Hash/HashTest.php
@@ -32,6 +32,21 @@ App::uses('Hash', 'Utility');
 class HashTest extends CakeTestCase {
 
 /**
+ * Runs the test case and collects the results in a TestResult object.
+ * If no TestResult object is passed a new one will be created.
+ * This method is run for each test method in this class
+ *
+ * @param PHPUnit_Framework_TestResult $result The test result object
+ * @return PHPUnit_Framework_TestResult
+ * @throws InvalidArgumentException
+ */
+	public function run(PHPUnit_Framework_TestResult $result = null) {
+		if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+			return parent::run($result);
+		}
+	}
+
+/**
  * Data provider
  *
  * @return array

--- a/TestSuite/NetCommonsTreeBehaviorCase.php
+++ b/TestSuite/NetCommonsTreeBehaviorCase.php
@@ -48,8 +48,6 @@ abstract class NetCommonsTreeBehaviorCase extends NetCommonsModelTestCase {
  * @var array
  */
 	public $fixtures = array(
-		'plugin.net_commons.net_commons_tree_model',
-		'plugin.net_commons.cake_tree_model',
 	);
 
 /**
@@ -58,6 +56,24 @@ abstract class NetCommonsTreeBehaviorCase extends NetCommonsModelTestCase {
  * @var string
  */
 	public $plugin = 'net_commons';
+
+/**
+ * Fixtures load
+ *
+ * @param string $name The name parameter on PHPUnit_Framework_TestCase::__construct()
+ * @param array  $data The data parameter on PHPUnit_Framework_TestCase::__construct()
+ * @param string $dataName The dataName parameter on PHPUnit_Framework_TestCase::__construct()
+ * @return void
+ */
+	public function __construct($name = null, array $data = array(), $dataName = '') {
+		if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+			$this->fixtures = [
+				'plugin.net_commons.net_commons_tree_model',
+				'plugin.net_commons.cake_tree_model',
+			];
+		}
+		parent::__construct($name, $data, $dataName);
+	}
 
 /**
  * Runs the test case and collects the results in a TestResult object.


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1337