### PR TITLE
移行シェルで、Current::$current['User']にセットされないため修正

### DIFF
--- a/Lib/CurrentLib.php
+++ b/Lib/CurrentLib.php
@@ -397,6 +397,7 @@ class CurrentLib extends LibAppObject {
 		}
 
 		if ($isLoginChanged ||
+				! isset(self::$current['User']) ||
 				empty($this->_controller->request->params['requested'])) {
 			self::$current['User'] = $this->CurrentLibUser->getLoginUser();
 		}


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1468