### PR TITLE
feat: send cache-control header when not logging in

### DIFF
--- a/Controller/NetCommonsAppController.php
+++ b/Controller/NetCommonsAppController.php
@@ -271,15 +271,15 @@ class NetCommonsAppController extends Controller {
 			$this->CurrentLib->terminate($this);
 		}
 
-        if (Current::isLogin()) {
-            // ログインしている場合はキャッシュしない
-            $this->response->header('Pragma', 'no-cache');
-        } else {
-            // CDN（Proxy）で使われるキャッシュヘッダーをセットする
-            $this->response->header('Cache-Control', 's-maxage=60, public');
-        }
+		if (Current::isLogin()) {
+			// ログインしている場合はキャッシュしない
+			$this->response->header('Pragma', 'no-cache');
+		} else {
+			// CDN（Proxy）で使われるキャッシュヘッダーをセットする
+			$this->response->header('Cache-Control', 's-maxage=60, public');
+		}
 
-        parent::afterFilter();
+		parent::afterFilter();
 	}
 
 /**

--- a/Controller/NetCommonsAppController.php
+++ b/Controller/NetCommonsAppController.php
@@ -271,7 +271,15 @@ class NetCommonsAppController extends Controller {
 			$this->CurrentLib->terminate($this);
 		}
 
-		parent::afterFilter();
+        if (Current::isLogin()) {
+            // ログインしている場合はキャッシュしない
+            $this->response->header('Pragma', 'no-cache');
+        } else {
+            // CDN（Proxy）で使われるキャッシュヘッダーをセットする
+            $this->response->header('Cache-Control', 's-maxage=60, public');
+        }
+
+        parent::afterFilter();
 	}
 
 /**


### PR DESCRIPTION
## やったこと
- ログインしている場合は、HTTP ヘッダーに `Pragma: no-cache` をセットする
- ログインしていない場合、かつ、エラーページでない場合は、`Cache-Control: s-maxage=, public` を設定する

## なぜやるか
CDNなどで、ログイン後のページはキャッシュして欲しくないため。

s-maxage は、ブラウザのキャッシュには影響せず、プロクシ（CDNなど）にのみ影響を与えるヘッダーです。

## 積み残し
- s-maxage の適切な数値の決定
    - いい感じなキャッシュinvalidate機構があれば、無制限でも問題はないはずです
