### PR TITLE
feat: application.local.yml replaces application.yml

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -27,13 +27,13 @@ if (! defined('NC3_VERSION')) {
 
 // Load application configurations
 $conf = array();
-$files = array('application.yml', 'application.local.yml');
+$files = array('application.yml', 'application.local.yml', env('HTTP_HOST') . '.yml', env('HTTP_X_FORWARDED_HOST') . '.yml');
 foreach ($files as $file) {
-	if (file_exists(APP . 'Config' . DS . $file)) {
-		$conf = array_merge($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));
-		Configure::write($conf);
-	}
+    if (file_exists(APP . 'Config' . DS . $file)) {
+        $conf = array_replace_recursive($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));
+    }
 }
+Configure::write($conf);
 
 // Load all plugins
 $plugins = App::objects('plugins');

--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -29,9 +29,9 @@ if (! defined('NC3_VERSION')) {
 $conf = array();
 $files = array('application.yml', 'application.local.yml', 'application.' . env('HTTP_HOST') . '.yml', 'application.' . env('HTTP_X_FORWARDED_HOST') . '.yml');
 foreach ($files as $file) {
-    if (file_exists(APP . 'Config' . DS . $file)) {
-        $conf = array_replace_recursive($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));
-    }
+	if (file_exists(APP . 'Config' . DS . $file)) {
+		$conf = array_replace_recursive($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));
+	}
 }
 Configure::write($conf);
 

--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -27,7 +27,10 @@ if (! defined('NC3_VERSION')) {
 
 // Load application configurations
 $conf = array();
-$files = array('application.yml', 'application.local.yml', 'application.' . env('HTTP_HOST') . '.yml', 'application.' . env('HTTP_X_FORWARDED_HOST') . '.yml');
+$files = array('application.yml',
+	'application.local.yml',
+	'application.' . env('HTTP_HOST') . '.yml',
+	'application.' . env('HTTP_X_FORWARDED_HOST') . '.yml');
 foreach ($files as $file) {
 	if (file_exists(APP . 'Config' . DS . $file)) {
 		$conf = array_replace_recursive($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));

--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -27,7 +27,7 @@ if (! defined('NC3_VERSION')) {
 
 // Load application configurations
 $conf = array();
-$files = array('application.yml', 'application.local.yml', env('HTTP_HOST') . '.yml', env('HTTP_X_FORWARDED_HOST') . '.yml');
+$files = array('application.yml', 'application.local.yml', 'application.' . env('HTTP_HOST') . '.yml', 'application.' . env('HTTP_X_FORWARDED_HOST') . '.yml');
 foreach ($files as $file) {
     if (file_exists(APP . 'Config' . DS . $file)) {
         $conf = array_replace_recursive($conf, Spyc::YAMLLoad(APP . 'Config' . DS . $file));


### PR DESCRIPTION
## やったこと
複数の application.yml系を用意した場合に、application.yml をベースとして、差分があった箇所のみを上書きするようにしました。
現状では、後に読み込まれたymlの内容で、設定全部が上書きされるようになっています。

また、application.yml 系のファイル名として、 httpヘッダーのHost および、X-FORWARDED-HOSTも使うようにしました。

## なぜやるか
同じ環境に複数のドメインからアクセスした場合に、fullBaseUrlをアクセス元に合わせて書き換える必要があったため。
Router::fullBaseUrl() で fullBaseUrl は取得できるようなんですが、 application.yml が使われているようなので、application.yml の読み込み周りを変更してみました。

ドメインごとに application.yml と fullBaseUrl だけが違う xxx.yml を用意するよりも、差分がある箇所のみ変更したymlを用意する方がミスが減ると考えたので、差分を読み込んで、更新がある箇所のみ上書きするようにしました。


### Host および、X-FORWARDED-HOST
フラット化で、どのapplication.yml を使うかを決めるためHost名を利用するようにしました。
X-FORWARDED-HOST は、CDNからアクセスした場合にセットされるヘッダーになります。

## 懸念点
- Security 以下の内容の扱いをどうすべきか
    - Security の内容は、ホストごとの方に書かれるとよさそう
- application.yml とホストの組み合わせをもっとセキュアにやる方法はないか

## eg:
### application.yml
```
---
debug: 0
App:
  imageBaseUrl: img/
  cssBaseUrl: css/
  fullBaseUrl: http://html.local
```

### application.local.yml
```
---
App:
  fullBaseUrl: https://willbooster.com
  sCacheMaxAge: 3600
```

### この場合
```
---
debug: 0
App:
  imageBaseUrl: img/
  cssBaseUrl: css/
  fullBaseUrl: https://willbooster.com
  sCacheMaxAge: 3600
```
を読み込んだ場合と同じ内容が、Configure に書き込まれます。	