### PR TITLE
style: add .editorconfig to standardize coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,yml}]
+indent_size = 2
+indent_style = space
+
+[*.json]
+indent_size = 4
+indent_style = space
+
+[*.{css,ctp,php}]
+indent_style = tab
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
## やったこと
既存コードと異なるスタイルのコードをコミットしてしまわないように、様々なエディタ/IDEに対応した共通のコードフォーマットの設定ファイル (EditorConfig) を追加しました。

EditorConfigの詳細は https://editorconfig.org/ を御覧ください。

## お願い
既存コードを読みながら設定ファイルを書きましたが、日が浅いので見落とし・誤りがあるかもしれません。 @s-nakajima 既存コードに反するような設定がないかご確認いただければ幸いです。