### PR TITLE
chore: ignore config files of JetBrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ app/tmp/*
 app/[Cc]onfig/core.php
 app/[Cc]onfig/database.php
 !empty
+
+.idea/


### PR DESCRIPTION
## やったこと

JetBrains社製のIDEの設定ファイルをコミットしてしまわないように、 `.gitignore` に追加した。