### PR TITLE
feat(CDN): Clear CDN cache when NetCommonsCache clears cache

### DIFF
--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -15,10 +15,14 @@
  * @author Shohei Nakajima <nakajimashouhei@gmail.com>
  * @package NetCommons\NetCommons\Utility
  */
-class NetCommonsCDNCache
-{
-	public function clear()
-	{
+class NetCommonsCDNCache {
+
+/**
+ * Clear CDN Cache
+ *
+ * @return void
+ */
+	public function clear() {
 		$data = array(
 			"Site" => array(
 				"Domain" => Configure::read('App.fullBaseUrl')
@@ -33,7 +37,7 @@ class NetCommonsCDNCache
 		curl_setopt($curl, CURLOPT_POST, true);
 		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
 
 		curl_exec($curl);

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @package NetCommons\NetCommons\Utility
+ */
+class NetCommonsCDNCache
+{
+	public function clear()
+	{
+		$data = array(
+			"Site" => array(
+				"Domain" => Configure::read('App.fullBaseUrl')
+			)
+		);
+
+		$curl = curl_init();
+		$accessToken = Configure::read('CDN.accessToken');
+		$accessTokenSecret = Configure::read('CDN.accessTokenSecret');
+
+		curl_setopt($curl, CURLOPT_URL, Configure::read('CDN.apiUrl') . 'deleteallcache');
+		curl_setopt($curl, CURLOPT_POST, true);
+		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
+		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+
+		curl_exec($curl);
+		curl_close($curl);
+	}
+}

--- a/Utility/NetCommonsCache.php
+++ b/Utility/NetCommonsCache.php
@@ -10,6 +10,7 @@
  */
 
 App::uses('Cache', 'Cache');
+App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
 
 /**
  * Configure the cache used for general framework caching. Path information,
@@ -201,6 +202,7 @@ class NetCommonsCache {
 			//if ($engine && $engine->key($this->__cacheName)) {
 			//	$success = Cache::delete($this->__cacheName, $this->__cacheType);
 				Cache::delete($this->__cacheName, $this->__cacheType);
+				(new NetCommonsCDNCache())->clear();
 			//} else {
 			//	$success = true;
 			//}


### PR DESCRIPTION
## やったこと
- CDN(さくらのウェブアクセラレーター)削除専用のクラスみたいなのを作る
- 既存のキャッシュの削除部分にCDN削除をいれる
- application.yml にて以下を設定する必要があります。
   - CDN.apiUrl
   - CDN.accessToken
   - CDN.accessTokenSecret

```
CDN:
  apiUrl: 
  cacheMaxAge: 3600
  accessToken: 
  accessTokenSecret:
```

## なぜやるか
CDNのキャッシュを、更新が必要なタイミングで削除するためです。

## 今後
このPRで追加された機能を使って、他プラグインでキャッシュの削除が妥当だと思われるタイミングで、削除処理を実施します。