### PR TITLE
feat(CDN): add CDN Cache Invalidate behavior

### DIFF
--- a/Model/Behavior/CDNCacheInvalidateBehavior.php
+++ b/Model/Behavior/CDNCacheInvalidateBehavior.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * DB 保存時に CDN キャッシュを削除する
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @author Wataru Nishimoto <watura@willbooster.com>
+ * @author Kazunori Sakamoto <exkazuu@willbooster.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+App::uses('ModelBehavior', 'Model');
+App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
+
+/**
+ * DB 保存時に CDN キャッシュを削除する
+ * @author Wataru Nishimoto <watura@willbooster.com>
+ * @author Kazunori Sakamoto <exkazuu@willbooster.com>
+ * @package NetCommons\NetCommons\Model\Befavior
+ */
+class CDNCacheInvalidateBehavior extends ModelBehavior {
+
+/**
+ * Delete CDN Cache after save
+ *
+ * @param Model $model Model using this behavior
+ * @param bool $created True if this save created a new record
+ * @param array $options Options passed from Model::save().
+ * @return bool
+ * @see Model::save()
+ * @throws InternalErrorException
+ */
+	public function afterSave(Model $model, $created, $options = array()) {
+		$cdn = new NetCommonsCDNCache();
+		$cdn->clear();
+		return true;
+	}
+}

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -15,10 +15,14 @@
  * @author Shohei Nakajima <nakajimashouhei@gmail.com>
  * @package NetCommons\NetCommons\Utility
  */
-class NetCommonsCDNCache
-{
-	public function clear()
-	{
+class NetCommonsCDNCache {
+
+/**
+ * Clear CDN Cache
+ *
+ * @return void
+ */
+	public function clear() {
 		$data = array(
 			"Site" => array(
 				"Domain" => Configure::read('App.fullBaseUrl')
@@ -33,7 +37,7 @@ class NetCommonsCDNCache
 		curl_setopt($curl, CURLOPT_POST, true);
 		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
 
 		curl_exec($curl);

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @package NetCommons\NetCommons\Utility
+ */
+class NetCommonsCDNCache
+{
+	public function clear()
+	{
+		$data = array(
+			"Site" => array(
+				"Domain" => Configure::read('App.fullBaseUrl')
+			)
+		);
+
+		$curl = curl_init();
+		$accessToken = Configure::read('CDN.accessToken');
+		$accessTokenSecret = Configure::read('CDN.accessTokenSecret');
+
+		curl_setopt($curl, CURLOPT_URL, Configure::read('CDN.apiUrl') . 'deleteallcache');
+		curl_setopt($curl, CURLOPT_POST, true);
+		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
+		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+
+		curl_exec($curl);
+		curl_close($curl);
+	}
+}

--- a/Utility/NetCommonsCache.php
+++ b/Utility/NetCommonsCache.php
@@ -10,6 +10,7 @@
  */
 
 App::uses('Cache', 'Cache');
+App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
 
 /**
  * Configure the cache used for general framework caching. Path information,
@@ -201,6 +202,7 @@ class NetCommonsCache {
 			//if ($engine && $engine->key($this->__cacheName)) {
 			//	$success = Cache::delete($this->__cacheName, $this->__cacheType);
 				Cache::delete($this->__cacheName, $this->__cacheType);
+				(new NetCommonsCDNCache())->clear();
 			//} else {
 			//	$success = true;
 			//}


### PR DESCRIPTION
## やったこと
CDNのキャッシュを削除するための、behaviorの追加。
この behavior をセットすると、DB 保存時に CDN のキャッシュを削除する

この behavior の利用方法は、各プラグインで、 `actsAs` に追加するだけです。


## なぜやるか
一部のNetCommonsCacheを使っているクラス以外のクラスでもCDNのキャッシュ削除をやりたい場合があるため

## 問題点
必要になるプラグインを全てみつけて、全てにPRを作るのが、非常に大変そう

かといって、behavior がセットされていたら、`キャッシュをクリアしない` という実装は、モデルの実装として、適切な実装ではなさそう