### PR TITLE
feat(CDN): invalidate CDN cache when model committed

### DIFF
--- a/Model/NetCommonsAppModel.php
+++ b/Model/NetCommonsAppModel.php
@@ -102,7 +102,7 @@ class NetCommonsAppModel extends Model {
  * invalidateCDN cache
  * DB 保存/削除時に CDN のキャッシュを invalidate するか
  *
- * @var boolean
+ * @var bool
  */
 	public $invalidateCDN = true;
 

--- a/Model/NetCommonsAppModel.php
+++ b/Model/NetCommonsAppModel.php
@@ -11,6 +11,7 @@
  */
 
 App::uses('Model', 'Model');
+App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
 App::uses('ValidateMerge', 'NetCommons.Utility');
 
 /**
@@ -96,6 +97,14 @@ class NetCommonsAppModel extends Model {
  * @var string
  */
 	public $contentKey = null;
+
+/**
+ * invalidateCDN cache
+ * DB 保存/削除時に CDN のキャッシュを invalidate するか
+ *
+ * @var boolean
+ */
+	public $invalidateCDN = true;
 
 /**
  * Constructor. DataSourceの選択
@@ -319,6 +328,11 @@ class NetCommonsAppModel extends Model {
 	public function commit() {
 		$dataSource = $this->getDataSource();
 		$dataSource->commit();
+
+		if ($this->invalidateCDN) {
+			$cdnCache = new NetCommonsCDNCache();
+			$cdnCache->invalidate();
+		}
 	}
 
 /**

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -15,10 +15,14 @@
  * @author Shohei Nakajima <nakajimashouhei@gmail.com>
  * @package NetCommons\NetCommons\Utility
  */
-class NetCommonsCDNCache
-{
-	public function clear()
-	{
+class NetCommonsCDNCache {
+
+/**
+ * Clear CDN Cache
+ *
+ * @return void
+ */
+	public function clear() {
 		$data = array(
 			"Site" => array(
 				"Domain" => Configure::read('App.fullBaseUrl')
@@ -33,7 +37,7 @@ class NetCommonsCDNCache
 		curl_setopt($curl, CURLOPT_POST, true);
 		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
 		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
 
 		curl_exec($curl);

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+/**
+ * NetCommons用CDNキャッシュ Utility
+ *
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @package NetCommons\NetCommons\Utility
+ */
+class NetCommonsCDNCache
+{
+	public function clear()
+	{
+		$data = array(
+			"Site" => array(
+				"Domain" => Configure::read('App.fullBaseUrl')
+			)
+		);
+
+		$curl = curl_init();
+		$accessToken = Configure::read('CDN.accessToken');
+		$accessTokenSecret = Configure::read('CDN.accessTokenSecret');
+
+		curl_setopt($curl, CURLOPT_URL, Configure::read('CDN.apiUrl') . 'deleteallcache');
+		curl_setopt($curl, CURLOPT_POST, true);
+		curl_setopt($curl, CURLOPT_USERPWD, "$accessToken:$accessTokenSecret");
+		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+
+		curl_exec($curl);
+		curl_close($curl);
+	}
+}

--- a/Utility/NetCommonsCDNCache.php
+++ b/Utility/NetCommonsCDNCache.php
@@ -13,16 +13,18 @@
  * NetCommons用CDNキャッシュ Utility
  *
  * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @author Wataru Nishimoto <watura@willbooster.com>
+ * @author Kazunori Sakamoto <exkazuu@willbooster.com>
  * @package NetCommons\NetCommons\Utility
  */
 class NetCommonsCDNCache {
 
 /**
- * Clear CDN Cache
+ * Invalidate CDN Cache
  *
  * @return void
  */
-	public function clear() {
+	public function invalidate() {
 		$data = array(
 			"Site" => array(
 				"Domain" => Configure::read('App.fullBaseUrl')

--- a/Utility/NetCommonsCache.php
+++ b/Utility/NetCommonsCache.php
@@ -10,7 +10,6 @@
  */
 
 App::uses('Cache', 'Cache');
-App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
 
 /**
  * Configure the cache used for general framework caching. Path information,
@@ -202,7 +201,6 @@ class NetCommonsCache {
 			//if ($engine && $engine->key($this->__cacheName)) {
 			//	$success = Cache::delete($this->__cacheName, $this->__cacheType);
 				Cache::delete($this->__cacheName, $this->__cacheType);
-				(new NetCommonsCDNCache())->clear();
 			//} else {
 			//	$success = true;
 			//}

--- a/Utility/NetCommonsCache.php
+++ b/Utility/NetCommonsCache.php
@@ -10,6 +10,7 @@
  */
 
 App::uses('Cache', 'Cache');
+App::uses('NetCommonsCDNCache', 'NetCommons.Utility');
 
 /**
  * Configure the cache used for general framework caching. Path information,
@@ -201,6 +202,7 @@ class NetCommonsCache {
 			//if ($engine && $engine->key($this->__cacheName)) {
 			//	$success = Cache::delete($this->__cacheName, $this->__cacheType);
 				Cache::delete($this->__cacheName, $this->__cacheType);
+				(new NetCommonsCDNCache())->clear();
 			//} else {
 			//	$success = true;
 			//}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "netcommons/mails": "@dev",
         "netcommons/topics": "@dev",
         "netcommons/menus": "@dev",
-        "netcommons/clean-up": "@dev"
+        "netcommons/clean-up": "@dev",
+        "ext-curl": "*"
     },
     "config": {
         "vendor-dir": "vendors",


### PR DESCRIPTION
## やったこと
- NetCommonsAppModel に `$invalidateCDN` を定義
- Model で commit が呼ばれた際に CDN のキャッシュを invalidate する
- clear を invalidate にリネーム
- NetCommonsCache でキャッシュを削除するのをやめる
  - NetCommonsCache でキャッシュ削除されるタイミング間際で、 Model も更新されていると考えられる

## なぜやるか

https://github.com/NetCommons3/NetCommons/pull/568 では、モデルにビヘイビアとしてキャッシュ削除処理を追加できるようにしました。
ビヘイビアを追加していく問題として、有効にするためには追加しなければならないという問題があります。
手動で、必要となる全てのモデルのビヘイビアに追加しようとしたとき、多くの場合、追加もれが発生します。

なので、基本的に全てのデータのcommit時にCDNのキャッシュを削除するようにし、削除したくない場合には、 `invalidateCDN` に false を入れればいいというふうにしました。

NetCommonsAppModel は全てのモデルで継承されているという前提のもとに実装しています。