### PR TITLE
feat: able to set db config from applicaiton.yml

### DIFF
--- a/Model/NetCommonsAppModel.php
+++ b/Model/NetCommonsAppModel.php
@@ -168,9 +168,12 @@ class NetCommonsAppModel extends Model {
 		//
 		//// Randomly use a slave
 		////$dataSource = (count($slaves) !== 0) ? $slaves[rand(0, count($slaves) - 1)] : 'master';
+		$database = Configure::read('App.database');
+		if (isset($database)) {
+			return $database;
+		}
+		return 'master';
 
-		$dataSource = 'master';
-		return $dataSource;
 	}
 
 /**
@@ -179,7 +182,12 @@ class NetCommonsAppModel extends Model {
  * @return void
  */
 	public function setMasterDataSource() {
-		self::$__changeDbConfig = 'master';
+		$database = Configure::read('App.database');
+		if (isset($database)) {
+			self::$__changeDbConfig = $database;
+		} else {
+			self::$__changeDbConfig = 'master';
+		}
 	}
 
 /**


### PR DESCRIPTION
## やったこと
参照する DB 設定をアプリケーション内で変更できるようにした

## テスト方法
1.  db に root 以外のユーザーを追加し、とりあえず、root と同じ権限を与える
2. database.php の master を master2 としてコピーする
3. master2 の user を 1 で追加したユーザーにする
4. application.html.local:9096.yml と application.test.local:9096.yml を用意する

```
App:
  fullBaseUrl: http://html.local:9096
  database: master
```

```
App:
  fullBaseUrl: http://test.local:9096
  database: master2
```

5. /etc/hosts をいじって↑のurlで見れるようにする
6. 2つのurlにアクセスしたときに、違う設定が使われていることを確認する
    - mysql にログインして show processlist 連打とか