### PR TITLE
change: NetCommonsComponent::renderJsonでJSON_HEX_TAG | JSON_HEX_AMP |…

### DIFF
--- a/Controller/Component/NetCommonsComponent.php
+++ b/Controller/Component/NetCommonsComponent.php
@@ -57,6 +57,7 @@ class NetCommonsComponent extends Component {
 		$results = NetCommonsAppController::camelizeKeyRecursive($results);
 		$this->controller->set(compact('results'));
 		$this->controller->set('_serialize', 'results');
+		$this->controller->set('_jsonOptions', JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
 	}
 
 /**


### PR DESCRIPTION
JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOTオプションを有効にした

https://github.com/NetCommons3/NetCommons/commit/018cb71dd5f0ec9dbb0519f1aacdafc25eda5663 と同じ変更をNetCommonsComponent::renderJsonにも適用したかたちです。