### PR TITLE
fix: AuthComponentがロードされていないと、Fatalエラーが発生し、正しいエラーを返さないため修正

### DIFF
--- a/Controller/Component/NetCommonsComponent.php
+++ b/Controller/Component/NetCommonsComponent.php
@@ -57,7 +57,10 @@ class NetCommonsComponent extends Component {
 		$results = NetCommonsAppController::camelizeKeyRecursive($results);
 		$this->controller->set(compact('results'));
 		$this->controller->set('_serialize', 'results');
-		$this->controller->set('_jsonOptions', JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+		$this->controller->set(
+			'_jsonOptions',
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
 	}
 
 /**

--- a/Controller/NetCommonsAppController.php
+++ b/Controller/NetCommonsAppController.php
@@ -257,6 +257,7 @@ class NetCommonsAppController extends Controller {
  * @param bool $local If true, restrict referring URLs to local server
  * @return string Referring URL
  * @link https://book.cakephp.org/2.0/en/controllers.html#Controller::referer
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  */
 	public function referer($default = null, $local = true) {
 		return parent::referer($default, $local);

--- a/Error/NetCommonsExceptionRenderer.php
+++ b/Error/NetCommonsExceptionRenderer.php
@@ -151,7 +151,8 @@ class NetCommonsExceptionRenderer extends ExceptionRenderer {
 
 		} elseif ($this->_is403And404($error)) {
 			list($redirect, $redirectUrl) = $this->_get403And404Redirect();
-			if (! $this->controller->request->is('ajax')) {
+			if (! $this->controller->request->is('ajax') &&
+					$this->__loadedAuthComponent()) {
 				$this->controller->Auth->redirectUrl($redirectUrl);
 			}
 
@@ -187,7 +188,7 @@ class NetCommonsExceptionRenderer extends ExceptionRenderer {
 				'net_commons', 'Under maintenance. Nobody is allowed to login except for administrators.'
 			);
 		} elseif ($message === 'Forbidden') {
-			if ($this->controller->Auth->user()) {
+			if ($this->__isLoggedIn()) {
 				$message = __d('net_commons', 'Permission denied. Bad account.');
 			} else {
 				$message = __d('net_commons', 'Permission denied. You must be logged.');
@@ -217,7 +218,7 @@ class NetCommonsExceptionRenderer extends ExceptionRenderer {
  * @return array array($redirect, $redirectUrl)
  */
 	protected function _get403And404Redirect() {
-		if ($this->controller->Auth->user()) {
+		if ($this->__isLoggedIn()) {
 			$referer = Router::parse($this->controller->request->referer(true));
 			$here = Router::parse($this->controller->request->here(false));
 
@@ -249,6 +250,24 @@ class NetCommonsExceptionRenderer extends ExceptionRenderer {
 		}
 
 		return array($redirect, $redirectUrl);
+	}
+
+/**
+ * Authコンポーネントがロードされているか否か
+ *
+ * @return bool
+ */
+	private function __loadedAuthComponent() {
+		return ! empty($this->controller->Auth);
+	}
+
+/**
+ * ログインしているかいない
+ *
+ * @return bool
+ */
+	private function __isLoggedIn() {
+		return $this->__loadedAuthComponent() && $this->controller->Auth->user();
 	}
 
 /**

--- a/Error/NetCommonsExceptionRenderer.php
+++ b/Error/NetCommonsExceptionRenderer.php
@@ -126,6 +126,7 @@ class NetCommonsExceptionRenderer extends ExceptionRenderer {
  *
  * @param Exception $error Exception
  * @return void
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 	public function error400($error) {
 		$message = $error->getMessage();


### PR DESCRIPTION
https://github.com/researchmap/RmNetCommons3/issues/1640