### PR TITLE
feat: serve static files from CDN

### DIFF
--- a/View/Helper/CDNCacheHelper.php
+++ b/View/Helper/CDNCacheHelper.php
@@ -23,7 +23,7 @@ class CDNCacheHelper extends AppHelper {
 	public function isCacheable() {
 		$nonCacheable = (isset($this->_View->response->header()['Pragma']) &&
 				$this->_View->response->header()['Pragma'] === 'no-cache') ||
-			strncmp('origin-', $_SERVER['SERVER_NAME'], 7) !== 0;
+			strncmp('origin-', $_SERVER['HTTP_HOST'], 7) !== 0;
 		return !$nonCacheable;
 	}
 }

--- a/View/Helper/NetCommonsHtmlHelper.php
+++ b/View/Helper/NetCommonsHtmlHelper.php
@@ -120,6 +120,15 @@ class NetCommonsHtmlHelper extends AppHelper {
 			self::$__convertPaths[$path] = $convUrl;
 			$covPaths[] = $convUrl;
 		}
+		if (strncmp($_SERVER['HTTP_HOST'], 'member-', 7) === 0) {
+			foreach ($covPaths as &$covPath) {
+				if (strncmp($covPath, '/', 1) === 0 &&
+						$covPath !== '/components/bootstrap/dist/css/bootstrap.min.css') {
+					$covPath = 'https://' . substr($_SERVER['HTTP_HOST'], 7) . $covPath;
+				}
+			}
+			unset($covPath);
+		}
 
 		return $covPaths;
 	}


### PR DESCRIPTION
ウェブアクセラレータ経由で静的ファイルを配信するための修正です。

ただし、現状では、クロスオリジンの制約により、CSSを経由して参照するファイル（フォントなど）の取得に失敗しています。
そのため、サーバー側の調整が完了するまでは、マージできません。