### PR TITLE
fix: 検索後に戻るボタンでもどったときにsendingマークが表示されっぱなしになるのを修正

### DIFF
--- a/webroot/js/base.js
+++ b/webroot/js/base.js
@@ -186,6 +186,15 @@ NetCommonsApp.controller('NetCommons.base',
       $scope.messages = {};
 
       /**
+       * 検索後に戻るボタンでもどったときにsendingマークが表示されっぱなしになるのを抑止
+       */
+      $window.onpageshow = function() {
+        $scope.$apply(function() {
+          $scope.sending = false;
+        });
+      };
+
+      /**
        * top
        *
        * @type {function}


### PR DESCRIPTION
Refs https://github.com/researchmap/RmNetCommons3/issues/2644