### PR TITLE
chnage: 表示しているpage_idがトップページとして認定されていなくてもページパーマリンクが空の場合は、full_permali…

### DIFF
--- a/Lib/Current/CurrentLibPage.php
+++ b/Lib/Current/CurrentLibPage.php
@@ -784,7 +784,7 @@ class CurrentLibPage extends LibAppObject {
 		} else {
 			$fullPermalink = '';
 		}
-		if ($pageId !== $topPage['Page']['id']) {
+		if ($pageId !== $topPage['Page']['id'] && $pagePermalink) {
 			$fullPermalink .= $pagePermalink;
 		} else {
 			$fullPermalink = '';


### PR DESCRIPTION
…nkは空としてトップページとするように修正

https://github.com/researchmap/RmNetCommons3/issues/1979#issuecomment-1014041884