### PR TITLE
fix: 件数ドロップダウンでNoticeが発生することがあるのを修正

### DIFF
--- a/View/Elements/limit_dropdown_toggle.ctp
+++ b/View/Elements/limit_dropdown_toggle.ctp
@@ -12,7 +12,7 @@
 
 <span class="btn-group">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-		<?php echo $displayNumberOptions[$currentLimit]; ?>
+		<?php echo $displayNumberOptions[$currentLimit] ?? ''; ?>
 		<span class="caret"></span>
 	</button>
 	<ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
件数ドロップダウンで$displayNumberOptionsにない$currentLimitが指定されるとNoticeになるのを修正 Refs https://github.com/researchmap/RmNetCommons3/issues/2667