### PR TITLE
fix: NetCommonsForm->checkboxの第一引数にモデル名を省略したときに、labelタグにforがcheckboxのidと異なることがあるバグ修正。

### DIFF
--- a/View/Helper/FormInputHelper.php
+++ b/View/Helper/FormInputHelper.php
@@ -262,7 +262,7 @@ class FormInputHelper extends AppHelper {
  * @return string
  */
 	private function __bootstrapCheckbox($fieldName, $checkboxClass, $label, $escape, $inputOptions) {
-		$domId = Hash::get($inputOptions, 'id', $this->domId($fieldName));
+		$domId = Hash::get($inputOptions, 'id', $this->Form->domId($fieldName));
 		$inputOptions = Hash::remove($inputOptions, 'type');
 
 		$input = '<div class="' . $checkboxClass . '">';


### PR DESCRIPTION
※基本動作には影響ない。テストも不要。